### PR TITLE
Floating Tab Updates

### DIFF
--- a/foursite-wordpress-promotion.php
+++ b/foursite-wordpress-promotion.php
@@ -45,7 +45,7 @@ function promotions_en_form_block() {
 }
 add_action( 'init', 'promotions_en_form_block' );
 
-function generate_en_form_shortcode($atts) {
+function fwp_generate_en_form_shortcode($atts) {
 	wp_enqueue_script('en-form-parent'); // Only load the script when the shortcode is used
     $shortcode_atts = shortcode_atts(
         array(
@@ -82,7 +82,7 @@ function generate_en_form_shortcode($atts) {
 
     return $shortcode;
 }
-add_shortcode('en-form', 'generate_en_form_shortcode');
+add_shortcode('en-form', 'fwp_generate_en_form_shortcode');
 
 function promotions_en_form_wp_enqueue_scripts() {
     wp_register_script( 'en-form-parent', plugins_url( '/en-form/dist/en-form-parent.js', __FILE__ ), array(), foursite_wordpress_promotion_VERSION, 'all' );

--- a/includes/acf-fields.php
+++ b/includes/acf-fields.php
@@ -2150,6 +2150,45 @@ add_action( 'acf/include_fields', function() {
 			'search_placeholder' => '',
 		),
 		array(
+			'key' => 'field_63e28926f3d25',
+			'label' => 'Trigger',
+			'name' => 'engrid_fsft_trigger_type',
+			'aria-label' => '',
+			'type' => 'select',
+			'instructions' => 'For Javascript Trigger, open the promotion with triggerPromotion(id); 
+		Replace "id" with your promotion id.',
+			'required' => 0,
+			'conditional_logic' => array(
+				array(
+					array(
+						'field' => 'field_63694582ec47e',
+						'operator' => '==',
+						'value' => 'floating_tab',
+					),
+				),
+			),
+			'wrapper' => array(
+				'width' => '50',
+				'class' => '',
+				'id' => '',
+			),
+			'choices' => array(
+				0 => 'Immediately',
+				'px' => 'On Pixel Scroll',
+				'%' => 'On Percentage Scroll',
+				'js' => 'Javascript Trigger',
+			),
+			'default_value' => false,
+			'return_format' => 'value',
+			'multiple' => 0,
+			'allow_null' => 0,
+			'ui' => 0,
+			'ajax' => 0,
+			'placeholder' => '',
+			'allow_custom' => 0,
+			'search_placeholder' => '',
+		),
+		array(
 			'key' => 'field_61f1e8cad1f27',
 			'label' => 'Seconds',
 			'name' => 'engrid_trigger_seconds',
@@ -2202,6 +2241,13 @@ add_action( 'acf/include_fields', function() {
 						'value' => 'px',
 					),
 				),
+				array(
+						array(
+							'field' => 'field_63e28926f3d25',
+							'operator' => '==',
+							'value' => 'px',
+						),
+					),
 			),
 			'wrapper' => array(
 				'width' => '50',
@@ -2232,6 +2278,13 @@ add_action( 'acf/include_fields', function() {
 						'value' => '%',
 					),
 				),
+				array(
+						array(
+							'field' => 'field_63e28926f3d25',
+							'operator' => '==',
+							'value' => '%',
+						),
+					),
 			),
 			'wrapper' => array(
 				'width' => '50',
@@ -2245,43 +2298,6 @@ add_action( 'acf/include_fields', function() {
 			'min' => '',
 			'max' => '',
 			'step' => '',
-		),
-		array(
-			'key' => 'field_63e28926f3d25',
-			'label' => 'Trigger',
-			'name' => 'engrid_fsft_trigger_type',
-			'aria-label' => '',
-			'type' => 'select',
-			'instructions' => 'For Javascript Trigger, open the promotion with triggerPromotion(id); 
-		Replace "id" with your promotion id.',
-			'required' => 0,
-			'conditional_logic' => array(
-				array(
-					array(
-						'field' => 'field_63694582ec47e',
-						'operator' => '==',
-						'value' => 'floating_tab',
-					),
-				),
-			),
-			'wrapper' => array(
-				'width' => '50',
-				'class' => '',
-				'id' => '',
-			),
-			'choices' => array(
-				0 => 'Immediately',
-				'js' => 'Javascript Trigger',
-			),
-			'default_value' => false,
-			'return_format' => 'value',
-			'multiple' => 0,
-			'allow_null' => 0,
-			'ui' => 0,
-			'ajax' => 0,
-			'placeholder' => '',
-			'allow_custom' => 0,
-			'search_placeholder' => '',
 		),
 		array(
 			'key' => 'field_61f1839713dff',

--- a/public/class-foursite-wordpress-promotion-public.php
+++ b/public/class-foursite-wordpress-promotion-public.php
@@ -578,8 +578,26 @@ class Foursite_Wordpress_Promotion_Public {
 				$fsft_link = get_field('engrid_fsft_link', $lightbox_id);
 				$fsft_css = get_field('engrid_css', $lightbox_id);
 				$fsft_trigger = get_field('engrid_fsft_trigger_type', $lightbox_id);
+				$engrid_trigger_scroll_pixels = get_field('engrid_trigger_scroll_pixels', $lightbox_id);
+				$engrid_trigger_scroll_percentage = get_field('engrid_trigger_scroll_percentage', $lightbox_id);
 				$fsft_svg = get_field('engrid_custom_svg', $lightbox_id);
 				$fsft_id = 'fs-donation-tab';
+
+				$trigger = 0;
+				switch($fsft_trigger) {
+					case "0":
+						$trigger = 0;
+						break;
+					case 'px':
+						$trigger = $engrid_trigger_scroll_pixels.'px';
+						break;
+					case '%':
+						$trigger = $engrid_trigger_scroll_percentage.'%';
+						break;
+					case 'js':
+						$trigger = 'js';
+						break;
+				}
 
 				$style = '';
 				if(!empty($fsft_colors['foreground'])) $style .= "color: {$fsft_colors['foreground']};";
@@ -616,7 +634,7 @@ class Foursite_Wordpress_Promotion_Public {
 					'promotion_type' => $engrid_promotion_type,
 					'css' => $engrid_css,
 					'html' => "<a href='{$fsft_link['url']}' id='{$fsft_id}' style='{$style}' class='{$classes} hover-candle' {$attributes}>{$fsft_link['label']}{$fsft_svg}</a>",
-					'trigger' => $fsft_trigger,
+					'trigger' => $trigger,
 					'cookie_name' => $engrid_cookie_name, 
 					'cookie_hours' => $engrid_cookie_hours, 
 					'open_lightbox' => ($fsft_link['engrid_use_lightbox'] == 'yes') ? true : false

--- a/public/floating-tab/fs-floating-tab.css
+++ b/public/floating-tab/fs-floating-tab.css
@@ -4,8 +4,9 @@
   align-items: center;
 
   box-shadow: 0 0 4px 4px rgba(0, 0, 0, 0.12);
-  transition: right 0.5s;
+  transition: right 1s;
   transform: rotate(-90deg);
+  transform-origin: bottom right;
 
   text-decoration: none;
   font-size: 18px;
@@ -16,13 +17,17 @@
   line-height: 18px;
   letter-spacing: 0.04em;
   padding: 18px 30px;
-  margin-right: 25px;
+  margin-right: 0;
 
   position: fixed;
-  top: 50%;
-  right: -70px;
+  top: 40%;
+  right: -100px;
 
   white-space: unset;
+}
+
+#fs-donation-tab.floating-tab-show {
+  right: 0;
 }
 
 #fs-donation-tab.fixed-in-page {


### PR DESCRIPTION
This Pull Request adds 2 new Triggers to the Floating Tab:

On Pixel Scroll: 
![CleanShot 2023-10-18 at 18 01 30@2x](https://github.com/4site-interactive-studios/4site-wordpress-promotions/assets/406341/261cf9fc-4f6a-4575-856a-f80b25996957)

On Percentage Scroll: 
![CleanShot 2023-10-18 at 18 02 49@2x](https://github.com/4site-interactive-studios/4site-wordpress-promotions/assets/406341/534b2c1f-1b0e-4d83-87ee-c3e271c22886)

When the Floating Tab is set to trigger on any of those options, we will hide the Floating Tab when you scroll back up:
![CleanShot 2023-10-18 at 18 05 10](https://github.com/4site-interactive-studios/4site-wordpress-promotions/assets/406341/072b90bc-4f5b-41b1-a4a9-b17fc9b6e222)

I've also added an animation when the Floating Tab shows up.

Let me know if you have questions!